### PR TITLE
Fetch logs from replicas

### DIFF
--- a/ipaperftest.py
+++ b/ipaperftest.py
@@ -84,7 +84,7 @@ module_utils = {cwd}/ansible-freeipa/plugins/module_utils
 ANSIBLE_FETCH_FILES_PLAYBOOK = """
 ---
 - name: Fetch IPA server log files
-  hosts: ipaserver
+  hosts: ipaserver, ipareplicas
   become: true
   tasks:
     - synchronize:


### PR DESCRIPTION
Add `ipareplicas` group to the list of hosts to collect logs from in the ansible playbook.

Signed-off-by: Antonio Torres <antorres@redhat.com>