### PR TITLE
freeipa-perftest.spec: Add python3-setuptools to BuildRequires

### DIFF
--- a/freeipa-perftest.spec
+++ b/freeipa-perftest.spec
@@ -15,6 +15,7 @@ BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  gcc
 BuildRequires:	python3-devel
+BuildRequires:  python3-setuptools
 
 %description
 freeipa-perftest is a performance measurement tool for


### PR DESCRIPTION
This is needed to build against Fedora 35+ chroots in copr.

Signed-off-by: Antonio Torres <antorres@redhat.com>