### PR TITLE
APITest: update client generation settings

### DIFF
--- a/src/ipaperftest/plugins/apitest.py
+++ b/src/ipaperftest/plugins/apitest.py
@@ -19,7 +19,9 @@ from ipaperftest.plugins.registry import registry
 class APITest(Plugin):
 
     def generate_clients(self, ctx):
-        for i in range(ctx.params['amount']):
+        self.commands_per_client = 25
+        n_clients = math.ceil(ctx.params['amount'] / self.commands_per_client)
+        for i in range(n_clients):
             idx = str(i).zfill(3)
             machine_name = "client{}".format(idx)
             yield(
@@ -27,7 +29,7 @@ class APITest(Plugin):
                     machine_name=machine_name,
                     box=ctx.params['client_image'],
                     hostname=machine_name + "." + self.domain.lower(),
-                    memory_size=768,
+                    memory_size=2048,
                     cpus_number=1,
                     extra_commands="",
                     ip=next(self.ip_generator),
@@ -69,8 +71,7 @@ class APITest(Plugin):
         )
 
         for i in range(ctx.params['amount']):
-            client_idx = math.floor(i / 50)
-            self.custom_logs.append("command{}log".format(str(i)))
+            client_idx = math.floor(i / self.commands_per_client)
             formated_api_cmd = ctx.params['command'].format(id=str(i))
             cmd = (
                 r"echo password | kinit admin;"
@@ -114,7 +115,7 @@ class APITest(Plugin):
         commands_succeeded = 0
         returncodes = ""
         for i in range(ctx.params['amount']):
-            client_idx = math.floor(i / 50)
+            client_idx = math.floor(i / self.commands_per_client)
             file_lines = (
                 sp.run(
                     "vagrant ssh {host} -c 'cat ~/command{id}log'".format(


### PR DESCRIPTION
APITest was generating "amount" clients. However in this test we want
one client per 50 commands. Also increase available memory to 1GB since
in this test we need more memory for handling all the commands and we
don't need to deploy as many clients as in other tests such as
EnrollmentTest.

Signed-off-by: Antonio Torres <antorres@redhat.com>