### PR TITLE
Restart libvirtd between executions

### DIFF
--- a/src/ipaperftest/core/plugin.py
+++ b/src/ipaperftest/core/plugin.py
@@ -125,6 +125,8 @@ class Plugin:
         print("Destroying previous VMs...")
         if os.path.exists("Vagrantfile"):
             sp.run(["vagrant", "destroy", "-f"], stdout=sp.PIPE)
+            sp.run(["systemctl", "restart", "libvirtd"], stdout=sp.PIPE)
+            sp.run(["sleep", "5"], stdout=sp.PIPE)
 
     def reset_sync_folder(self, ctx):
         """Clear up any previously synced data and prepare for new data"""


### PR DESCRIPTION
This resolved some VM startup failures seen when running the
authentication tests.

Signed-off-by: Rob Crittenden <rcritten@redhat.com>