### PR TITLE
AuthenticationTest: Add Active Directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ The controller must have the following software installed:
 * `vagrant`
 * `ansible`
 * `libvirt`
-* `vagrant-libvirt` (vagrant plugin)
 * `git`
 * `rsync`
+* Vagrant plugins
+   * `vagrant-libvirt`
+   * `winrm` (for AD support)
+   * `winrm-elevated` (for AD support)
+
 
 ## Usage
 

--- a/src/ipaperftest/core/main.py
+++ b/src/ipaperftest/core/main.py
@@ -123,6 +123,8 @@ class RunTest:
     help="Number of replicas to create.",
 )
 @click.option("--threads", default=10, help="Threads to run per client during AuthenticationTest.")
+@click.option("--ad-threads", default=0, help="Active Directory login threads "
+                                              "to run per client during AuthenticationTest.")
 @click.option("--command", help="Command to execute during APITest.")
 @click.option(
     "--private-key",
@@ -147,6 +149,7 @@ def main(
     server_image="antorres/fedora-34-ipa-client",
     amount=1,
     threads=10,
+    ad_threads=0,
     replicas=0,
     results_format="json",
     results_output_file=None,

--- a/src/ipaperftest/core/plugin.py
+++ b/src/ipaperftest/core/plugin.py
@@ -73,6 +73,7 @@ class Plugin:
         self.domain = "ipa.test"
         self.ip_generator = self.generate_ip()
         self.machine_configs = []
+        self.vagrant_additional_config = ""
         self.hosts = dict()
         self.custom_logs = []
 
@@ -175,6 +176,7 @@ class Plugin:
                 hostname="server." + self.domain.lower(),
                 memory_size=8192,
                 cpus_number=4,
+                extra_options="",
                 extra_commands="yum update -y && yum install sysstat -y",
                 ip=next(self.ip_generator),
             )
@@ -190,6 +192,7 @@ class Plugin:
                     hostname=name + "." + self.domain.lower(),
                     memory_size=8192,
                     cpus_number=4,
+                    extra_options="",
                     extra_commands="yum update -y && yum install sysstat -y",
                     ip=next(self.ip_generator),
                 )
@@ -201,7 +204,7 @@ class Plugin:
                 self.machine_configs.append(conf)
 
         # Related: https://github.com/hashicorp/vagrant/issues/4967
-        vagrant_additional_config = (
+        self.vagrant_additional_config += (
             "config.ssh.insert_key = false\n"
             'config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key", "%s"]'
             % ctx.params['private_key']
@@ -210,7 +213,7 @@ class Plugin:
         )
 
         file_contents = VAGRANTFILE_TEMPLATE.format(
-            vagrant_additional_config=vagrant_additional_config,
+            vagrant_additional_config=self.vagrant_additional_config,
             machine_configs="\n".join(self.machine_configs),
         )
         with open("Vagrantfile", "w") as f:
@@ -234,12 +237,12 @@ class Plugin:
             pair = line.replace("\n", "").replace("Host ", "").split("  HostName ")
             self.hosts[pair[0]] = pair[1]
 
-    def generate_ansibile_inventory(self, ctx):
+    def generate_ansible_inventory(self, ctx):
         # Each replica should have main server + all the other replicas
         # as servers so the topology is built correctly
         replica_lines = []
         for name, _ in self.hosts.items():
-            if name.startswith("client") or name.startswith("server"):
+            if not name.startswith("replica"):
                 continue
             servers = ["server." + self.domain]
             for other, _ in self.hosts.items():
@@ -254,6 +257,9 @@ class Plugin:
                 [name for name, _ in self.hosts.items() if name.startswith("client")]
             ),
             replica_hostnames="\n".join(replica_lines),
+            windows_ips="\n".join(
+                [ip for name, ip in self.hosts.items() if name.startswith("windows")]
+            )
         )
         with open("runner_metadata/inventory", "w") as f:
             f.write(inventory_str)
@@ -265,9 +271,12 @@ class Plugin:
     def ansible_ping(self, ctx):
         print("Sending ping to VMs...")
         ansible_runner.run(private_data_dir="runner_metadata",
-                           host_pattern="all",
+                           host_pattern="ipaserver,ipaclients,ipareplicas",
                            module="ping",
                            cmdline="--ssh-extra-args '-F vagrant-ssh-config'")
+        ansible_runner.run(private_data_dir="runner_metadata",
+                           host_pattern="windows",
+                           module="win_ping")
 
         if len(self.hosts.keys()) != len(self.machine_configs):
             yield Result(self, WARNING,
@@ -371,7 +380,7 @@ class Plugin:
             self.clone_ansible_freeipa,
             self.create_vms,
             self.collect_hosts,
-            self.generate_ansibile_inventory,
+            self.generate_ansible_inventory,
             self.generate_ssh_config,
             self.ansible_ping,
             self.configure_server,

--- a/src/ipaperftest/plugins/apitest.py
+++ b/src/ipaperftest/plugins/apitest.py
@@ -33,6 +33,7 @@ class APITest(Plugin):
                     hostname=machine_name + "." + self.domain.lower(),
                     memory_size=2048,
                     cpus_number=1,
+                    extra_options="",
                     extra_commands="",
                     ip=next(self.ip_generator),
                 )

--- a/src/ipaperftest/plugins/enrollmenttest.py
+++ b/src/ipaperftest/plugins/enrollmenttest.py
@@ -33,6 +33,7 @@ class EnrollmentTest(Plugin):
                     memory_size=384,
                     cpus_number=1,
                     extra_commands="",
+                    extra_options="",
                     ip=next(self.ip_generator),
                 )
             )


### PR DESCRIPTION
Add Active Directory support to AuthenticationTest. This will create a
Windows Server host and deploy Active Directory server on it. After
that, test users are created into AD and trust is established with the
IPA server.

The pamtest tool is also updated to support launching threads for
authenticating Active Directory users.

Signed-off-by: Antonio Torres <antorres@redhat.com>