### PR TITLE
Use client localtime for APITest instead of server time

### DIFF
--- a/src/ipaperftest/core/constants.py
+++ b/src/ipaperftest/core/constants.py
@@ -109,7 +109,6 @@ ipaserver_realm={realm}
 ipaadmin_password=password
 ipasssd_enable_dns_updates=yes
 ipaclient_no_nisdomain=yes
-ipaclient_no_ntp=yes
 
 [windows]
 {windows_ips}

--- a/src/ipaperftest/plugins/apitest.py
+++ b/src/ipaperftest/plugins/apitest.py
@@ -66,7 +66,8 @@ class APITest(Plugin):
         clients = [name for name, ip in self.hosts.items() if name.startswith("client")]
         local_run_time = (
             sp.run(
-                "vagrant ssh server -c 'date --date now+{}min +%H:%M'".format(
+                "vagrant ssh {} -c 'date --date now+{}min +%H:%M'".format(
+                    clients[0],
                     str(len(clients) * 2)
                 ),
                 shell=True,


### PR DESCRIPTION
Since commands will be scheduled and launched from the clients, we
should use the client localtime for scheduling instead of the server's,
that way we can avoid issues caused by differences in time configuration.

Signed-off-by: Antonio Torres <antorres@redhat.com>