### PR TITLE
APITest: collect command logs from clients

### DIFF
--- a/src/ipaperftest/plugins/apitest.py
+++ b/src/ipaperftest/plugins/apitest.py
@@ -20,6 +20,10 @@ from ipaperftest.plugins.registry import registry
 @registry
 class APITest(Plugin):
 
+    def __init__(self, registry):
+        super().__init__(registry)
+        self.custom_logs = ["command*log", ]
+
     def generate_clients(self, ctx):
         self.commands_per_client = 25
         n_clients = math.ceil(ctx.params['amount'] / self.commands_per_client)


### PR DESCRIPTION
Move the output collected from commands into the sync directory.

Signed-off-by: Antonio Torres <antorres@redhat.com>