### PR TITLE
Remove unneeded Result during AuthenticationTest post-process

### DIFF
--- a/src/ipaperftest/plugins/authenticationtest.py
+++ b/src/ipaperftest/plugins/authenticationtest.py
@@ -216,8 +216,6 @@ class AuthenticationTest(Plugin):
             total_threads += n_threads
 
         total_percentage = round((total_successes / total_threads) * 100)
-        yield Result(self, ERROR,
-                     error="None of the threads returned results.")
 
         print("{} threads out of {} succeeded ({}%)".format(
             total_successes, total_threads, total_percentage)


### PR DESCRIPTION
This Result is incorrectly returned, since it's purpose is to detect
when total_threads == 0, but that would cause a ZeroDivisionError that
is already handled by the generic exception catching in
7b9d3e756d11691d8d2078e17dc09ee177725355. Because of this, the Result is
only returned when in reality there are no errors.

Signed-off-by: Antonio Torres <antorres@redhat.com>