### PR TITLE
Use IdM-CI for provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+*.tar.gz
 Vagrantfile
+.vagrant/
 sync
-.vagrant
 runner_metadata/*
 *.pyc
 *.egg-info
@@ -22,4 +23,3 @@ src/depcomp
 src/install-sh
 src/missing
 src/stamp-h1
-

--- a/README.md
+++ b/README.md
@@ -4,19 +4,25 @@ Collection of performance and scalability-related testing scripts.
 
 ## Dependencies
 
-This tool uses Vagrant and Libvirt to deploy VMs for testing.
+This tool can use these providers to deploy VMs for testing:
+
+* Vagrant
+* IdM CI (uses Red Hat's internal infrastructure, needs authentication)
+
 The controller must have the following software installed:
 
-* `vagrant`
 * `ansible`
-* `libvirt`
 * `git`
 * `rsync`
+
+For using the Vagrant provider, these need to be installed as well:
+
+* `vagrant`
+* `libvirt`
 * Vagrant plugins
    * `vagrant-libvirt`
    * `winrm` (for AD support)
    * `winrm-elevated` (for AD support)
-
 
 ## Usage
 
@@ -25,23 +31,28 @@ Usage: ipaperftest [OPTIONS]
 
 Options:
   --test TEXT                    Test to execute.  [default: EnrollmentTest]
-  --client-image TEXT            Vagrant image to use for clients.  [default:
-                                 antorres/fedora-34-ipa-client]
-  --server-image TEXT            Vagrant image to use for server.  [default:
-                                 antorres/fedora-34-ipa-client]
+  --client-image TEXT            Image to use for clients.
+  --server-image TEXT            Image to use for server.
   --amount INTEGER               Size of the test.  [default: 1]
   --replicas INTEGER RANGE       Number of replicas to create.  [default:
                                  0;0<=x<=2]
   --threads INTEGER              Threads to run per client during
                                  AuthenticationTest.  [default: 10]
+  --ad-threads INTEGER           Active Directory login threads to run per
+                                 client during AuthenticationTest.  [default:
+                                 0]
   --command TEXT                 Command to execute during APITest.
-  --private-key TEXT             Private key needed to access VMs in case the
-                                 Vagrant default is not enough.
   --results-format [json|human]  Format to use for results output  [default:
                                  json]
   --results-output-file TEXT     File to write results output to
   --custom-repo-url TEXT         URL from custom repo to be configured on the
-                                 server hosts  [default: ]
+                                 server hosts. Make sure N-V-R is higher than
+                                 the packages available in the server image so
+                                 that your packages are used.  [default: ]
+  --provider [vagrant|idmci]     Provider to use during test execution
+                                 [default: idmci]
+  --private-key TEXT             Private key needed to access VMs in case the
+                                 default is not enough.
   --help                         Show this message and exit.  [default: False]
 ```
 
@@ -67,6 +78,12 @@ To use the environment:
 
 ```
 $ source venv/bin/activate
+```
+
+If you are using the IdM CI provider, the Ansible Vault password file needs to be set up:
+
+```
+$ echo 'IDMCI_VAULT_PASSWORD' > ~/.idmci-ansible-vault-password-file
 ```
 
 To run the tool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click
 ansible-runner
+mrack

--- a/src/ipaperftest/core/main.py
+++ b/src/ipaperftest/core/main.py
@@ -107,13 +107,11 @@ class RunTest:
 @click.option("--test", default="EnrollmentTest", help="Test to execute.")
 @click.option(
     "--client-image",
-    default="antorres/fedora-34-ipa-client",
-    help="Vagrant image to use for clients.",
+    help="Image to use for clients.",
 )
 @click.option(
     "--server-image",
-    default="antorres/fedora-34-ipa-client",
-    help="Vagrant image to use for server.",
+    help="Image to use for server.",
 )
 @click.option("--amount", default=1, help="Size of the test.")
 @click.option(
@@ -126,10 +124,6 @@ class RunTest:
 @click.option("--ad-threads", default=0, help="Active Directory login threads "
                                               "to run per client during AuthenticationTest.")
 @click.option("--command", help="Command to execute during APITest.")
-@click.option(
-    "--private-key",
-    help="Private key needed to access VMs in case the Vagrant default is not enough.",
-)
 @click.option(
     "--results-format",
     help="Format to use for results output",
@@ -146,21 +140,31 @@ class RunTest:
          "server image so that your packages are used.",
     default=""
 )
+@click.option(
+    "--provider",
+    help="Provider to use during test execution",
+    type=click.Choice(["vagrant", "idmci"], case_sensitive=False), default="idmci"
+)
+@click.option(
+    "--private-key",
+    help="Private key needed to access VMs in case the default is not enough.",
+)
 @click.pass_context
 def main(
     ctx,
     test,
     command,
     private_key,
-    client_image="antorres/fedora-34-ipa-client",
-    server_image="antorres/fedora-34-ipa-client",
+    client_image,
+    server_image,
     amount=1,
     threads=10,
     ad_threads=0,
     replicas=0,
     results_format="json",
     results_output_file=None,
-    custom_repo_url=""
+    custom_repo_url="",
+    provider="idmci"
 ):
 
     tests = RunTest(['ipaperftest.registry'])

--- a/src/ipaperftest/providers/idmci.py
+++ b/src/ipaperftest/providers/idmci.py
@@ -1,0 +1,107 @@
+#
+# Copyright (C) 2022 FreeIPA Contributors see COPYING for license
+#
+
+import os
+import subprocess as sp
+from ipaperftest.core.constants import IDMCI_HOST_TEMPLATE, IDMCI_METADATA_TEMPLATE
+from ipaperftest.providers.provider import Provider
+
+
+class IdMCIProvider(Provider):
+    """
+    IdM-CI provider. This uses Red Hat's internal infrastructure so
+    authentication is needed.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.default_private_key = "config/id_rsa"
+        self.windows_admin_password = "Secret123"
+
+    def check_requirements(self):
+        path = os.path.join(os.path.expanduser('~'), ".idmci-ansible-vault-password-file")
+        if not os.path.exists(path):
+            raise RuntimeError("Ansible Vault Password file "
+                  "(~/.idmci-ansible-vault-password-file) is not present.")
+
+    def cleanup(self, ctx):
+        """We clean up *before* an execution so that the VMs remain.
+
+           This is so we can evaluate what, if anything, went wrong.
+        """
+
+        if not os.path.exists("runner_metadata"):
+            return
+
+        sp.run(["python3", "idm-ci/scripts/te", "--phase", "teardown", "metadata.yaml"],
+               cwd="runner_metadata",
+               env=dict(os.environ,
+                        ANSIBLE_VAULT_PASSWORD_FILE="~/.idmci-ansible-vault-password-file"))
+
+    def setup(self, ctx):
+        sp.run(["git", "clone", "--depth=1",
+                "https://gitlab.cee.redhat.com/identity-management/idm-ci.git"],
+               cwd="runner_metadata", stdout=sp.PIPE)
+
+    def generate_metadata(self, ctx, machine_configs, domain):
+        """Create the metadata file
+
+           This directly controls creating the entries for the server
+           and replicas. A per-test generator is used to generate the
+           client entries.
+        """
+
+        # IdM-CI specific host types
+        types = {
+            "server": "ipalarge",
+            "client": "ipaclient",
+            "ad": "ad"
+        }
+
+        server_img = ctx.params["server_image"]
+        client_img = ctx.params["client_image"]
+        self.server_image = server_img if server_img else "fedora-34"
+        self.client_image = client_img if client_img else "fedora-34"
+
+        images = {
+            "server": self.server_image,
+            "client": self.client_image,
+            "ad": "win-2019",
+        }
+
+        hosts_metadata = ""
+        for conf in machine_configs:
+            hosts_metadata += IDMCI_HOST_TEMPLATE.format(
+                hostname=conf['hostname'],
+                group=types[conf['type']],
+                os=images[conf['type']]
+            )
+
+        file_contents = IDMCI_METADATA_TEMPLATE.format(
+            domain=domain.lower(),
+            hosts=hosts_metadata
+        )
+        with open("runner_metadata/metadata.yaml", "w") as f:
+            f.write(file_contents)
+
+    def create_vms(self, ctx):
+        print("Creating machines...")
+        sp.run(["python3", "idm-ci/scripts/te", "--upto", "prep", "metadata.yaml"],
+               cwd="runner_metadata",
+               env=dict(os.environ,
+                        ANSIBLE_VAULT_PASSWORD_FILE="~/.idmci-ansible-vault-password-file"))
+
+    def collect_hosts(self, ctx):
+        """Collect IP information on the configured hosts in a dict
+
+           hostname:ip
+        """
+        mrack_output = sp.run(["mrack", "list"],
+                              stderr=sp.PIPE, cwd="runner_metadata").stderr.decode("utf-8")
+        # mrack list output example:
+        # active fedora-34 41df92f5-5f47-426a-9267-47758d6b9098 fedora34.idmci.test 10.0.199.6 None None  # noqa: E501
+        for line in mrack_output.splitlines():
+            info = line.split(" ")
+            name = info[3].split(".")[0]  # don't include full domain
+            self.hosts[name] = info[4]

--- a/src/ipaperftest/providers/provider.py
+++ b/src/ipaperftest/providers/provider.py
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2022 FreeIPA Contributors see COPYING for license
+#
+
+class Provider:
+    """
+    Base class for different providers used during test execution
+    """
+
+    def __init__(self):
+        self.files_to_log = []
+        self.server_image = ""
+        self.client_image = ""
+        self.windows_admin_password = ""
+        self.default_private_key = ""  # path relative to runner_metadata
+        self.hosts = {}  # host:ip dictionary
+
+    def check_requirements(self, ctx):
+        pass
+
+    def cleanup(self, ctx):
+        pass
+
+    def setup(self, ctx):
+        pass
+
+    def generate_metadata(self, ctx, machine_configs, domain):
+        pass
+
+    def create_vms(self, ctx):
+        pass
+
+    def collect_hosts(self, ctx):
+        pass

--- a/src/ipaperftest/providers/vagrant.py
+++ b/src/ipaperftest/providers/vagrant.py
@@ -1,0 +1,136 @@
+#
+# Copyright (C) 2022 FreeIPA Contributors see COPYING for license
+#
+
+import os
+import subprocess as sp
+from ipaperftest.core.constants import VAGRANT_HOST_TEMPLATE, VAGRANTFILE_TEMPLATE
+from ipaperftest.providers.provider import Provider
+
+
+class VagrantProvider(Provider):
+    """
+    Vagrant provider.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.files_to_log.append("Vagrantfile")
+        self.default_private_key = "~/.vagrant.d/insecure_private_key"
+        self.windows_admin_password = "vagrant"
+
+    def generate_ip(self):
+        ip_x = 3
+        ip_y = 2
+
+        while True:
+            yield "192.168.{}.{}".format(ip_x, ip_y)
+            ip_y += 1
+            if ip_y == 255:
+                ip_y = 2
+                ip_x += 1
+                if ip_x == 256:
+                    raise RuntimeError("Ran out of IP addresses for private network")
+
+    def cleanup(self, ctx):
+        """We clean up *before* an execution so that the VMs remain.
+
+           This is so we can evaluate what, if anything, went wrong.
+        """
+
+        if os.path.exists("Vagrantfile"):
+            sp.run(["vagrant", "destroy", "-f"], stdout=sp.PIPE)
+            sp.run(["systemctl", "restart", "libvirtd"], stdout=sp.PIPE)
+            sp.run(["sleep", "5"], stdout=sp.PIPE)
+
+    def generate_metadata(self, ctx, machine_configs, domain):
+        """Create the Vagrantfile
+           This directly controls creating the entries for the server
+           and replicas. A per-test generator is used to generate the
+           client entries.
+        """
+
+        types = {
+            "server": {
+                "memory": 8192,
+                "cpus": 4,
+            },
+            "client": {
+                "memory": 1024,
+                "cpus": 1,
+            },
+            "ad": {
+                "memory": 8192,
+                "cpus": 4
+            }
+        }
+
+        server_img = ctx.params["server_image"]
+        client_img = ctx.params["client_image"]
+        self.server_image = server_img if server_img else "antorres/fedora-34-ipa-client"
+        self.client_image = client_img if client_img else "antorres/fedora-34-ipa-client"
+
+        images = {
+            "server": self.server_image,
+            "client": self.client_image,
+            "ad": "peru/windows-server-2019-standard-x64-eval",
+        }
+
+        ad_extra_options = """
+            {hostname}.vm.network :forwarded_port, guest: 3389, host:3389, id: "rdp", auto_correct:true
+            {hostname}.vm.network :forwarded_port, guest: 5986, host:5986, id: "winrm-ssl", auto_correct:true
+            {hostname}.vm.communicator = "winrm"
+            {hostname}.winrm.communicator = "winrm"
+            {hostname}.winrm.username = "Administrator"
+            {hostname}.winrm.retry_limit = 50
+            {hostname}.winrm.retry_delay = 10
+        """  # noqa: E501
+
+        ip_generator = self.generate_ip()
+
+        hosts_metadata = ""
+        for conf in machine_configs:
+            hosts_metadata += VAGRANT_HOST_TEMPLATE.format(
+                machine_name=conf['hostname'].split(".")[0],
+                hostname=conf['hostname'],
+                memory=types[conf["type"]]["memory"],
+                cpus=types[conf["type"]]["cpus"],
+                box=images[conf['type']],
+                ip=next(ip_generator),
+                extra_options=ad_extra_options.format(
+                    hostname=conf['hostname']) if conf['type'] == "ad" else ""
+            )
+
+        # Related: https://github.com/hashicorp/vagrant/issues/4967
+        vagrant_additional_config = (
+            "config.ssh.insert_key = false\n"
+            'config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key", "%s"]'
+            % ctx.params['private_key']
+            if ctx.params.get('private_key')
+            else ""
+        )
+
+        file_contents = VAGRANTFILE_TEMPLATE.format(
+            vagrant_additional_config=vagrant_additional_config,
+            machine_configs=hosts_metadata,
+        )
+        with open("Vagrantfile", "w") as f:
+            f.write(file_contents)
+
+    def create_vms(self, ctx):
+        """Bring up all the configured virtual machines"""
+        print("Creating VMs...")
+        sp.run(["vagrant", "up", "--parallel"])
+
+    def collect_hosts(self, ctx):
+        """Collect IP information on the configured hosts in a dict
+
+           hostname:ip
+        """
+        grep_output = sp.run(
+            "vagrant ssh-config | grep -i HostName -B 1",
+            shell=True, stdout=sp.PIPE).stdout.decode("utf-8")
+        host_lines = grep_output.split("--")
+        for line in host_lines:
+            pair = line.replace("\n", "").replace("Host ", "").split("  HostName ")
+            self.hosts[pair[0]] = pair[1]


### PR DESCRIPTION
Use IdM-CI to run the performance tests using Red Hat's internal
infrastructure instead of using Vagrant as a provisioner. This allows us
to run the tests without the need of having all the VMs on the same
host, which could cause limitations on the libvirt side in some
situations.

Signed-off-by: Antonio Torres <antorres@redhat.com>