### PR TITLE
APITest: measure test execution time

### DIFF
--- a/src/ipaperftest/providers/vagrant.py
+++ b/src/ipaperftest/providers/vagrant.py
@@ -56,7 +56,7 @@ class VagrantProvider(Provider):
                 "cpus": 4,
             },
             "client": {
-                "memory": 1024,
+                "memory": 2048,
                 "cpus": 1,
             },
             "ad": {


### PR DESCRIPTION
Measure how much time it takes to run all scheduled commands. We add a
sleep right before we start checking the command statuses so that the
wait time is not included in the measurement.

Signed-off-by: Antonio Torres <antorres@redhat.com>