### PR TITLE
APITest: write commands to script when running in sequential mode

### DIFF
--- a/src/ipaperftest/core/constants.py
+++ b/src/ipaperftest/core/constants.py
@@ -323,6 +323,21 @@ ANSIBLE_APITEST_CLIENT_CONFIG_PLAYBOOK = """
         state: started
 """
 
+ANSIBLE_APITEST_CLIENT_UPLOAD_SEQUENTIAL_SCRIPT_PLAYBOOK = """
+---
+- name: Upload script with commands to execute sequentially
+  hosts: ipaclients
+  become: yes
+  tasks:
+    - synchronize:
+        src: "{{{{ item }}}}"
+        dest: "/root"
+        mode: push
+        use_ssh_args: yes
+      with_items:
+        - apitest_sequential_commands.sh
+"""
+
 ANSIBLE_AUTHENTICATIONTEST_SERVER_CONFIG_PLAYBOOK = """
 ---
 - name: Configure server before execution


### PR DESCRIPTION
With high amount of commands (2000+) simply joining the list of commands
with && would fail with "/bin/sh: Argument list too long". Write
commands to script and run it instead.

Signed-off-by: Antonio Torres <antorres@redhat.com>