### PR TITLE
Add option to disable SELinux and enable forking in authtest

### DIFF
--- a/src/ipaperftest/core/constants.py
+++ b/src/ipaperftest/core/constants.py
@@ -504,3 +504,16 @@ ANSIBLE_AUTHENTICATIONTEST_AD_SERVER_CREATE_USERS_PLAYBOOK = """
         New-ADUser -SamAccountName $name -Name $name -AccountPassword $password -Enabled $True
       }}
 """
+
+ANSIBLE_AUTHENTICATIONTEST_NOSELINUX_CONFIG_PLAYBOOK = """
+---
+- name: Disable SELinux in SSSD
+  hosts: ipaclients
+  tasks:
+  - name: "Disable SELinux provider"
+    become: yes
+    lineinfile:
+      path: /etc/sssd/sssd.conf
+      line: selinux_provider = none
+      insertafter: id_provider = ipa
+"""

--- a/src/ipaperftest/core/main.py
+++ b/src/ipaperftest/core/main.py
@@ -123,6 +123,8 @@ class RunTest:
 @click.option("--threads", default=10, help="Threads to run per client during AuthenticationTest.")
 @click.option("--ad-threads", default=0, help="Active Directory login threads "
                                               "to run per client during AuthenticationTest.")
+@click.option("--disable-selinux", default=False, is_flag=True,
+              help="Disable the SSSD SELinux provider in all clients, enable forking in pamtest")
 @click.option("--command", help="Command to execute during APITest.")
 @click.option(
     "--results-format",
@@ -171,6 +173,7 @@ def main(
     amount=1,
     threads=10,
     ad_threads=0,
+    disable_selinux=False,
     replicas=0,
     results_format="json",
     results_output_file=None,


### PR DESCRIPTION
SSSD currently has a mutex when calling pam in threaded
more so it is effectively serialized. Add an option to call
PAM using fork() instead to run the authentications
simultaneously.

There is a lock in libsemanage which can cause failures
so disable the SELinux provicer as a workaround for that.

Signed-off-by: Rob Crittenden <rcritten@redhat.com>