### PR TITLE
AuthenticationTest: allow running forks with AD users

### DIFF
--- a/freeipa-perftest.spec
+++ b/freeipa-perftest.spec
@@ -1,6 +1,6 @@
 Name:           freeipa-perftest
 Version:        0.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A set of IPA performance tools
 
 License:        GPLv3
@@ -82,6 +82,9 @@ popd
 
 
 %changelog
+* Thu Sep 15 2022 Antonio Torres <antorres@redhat.com> - 0.4-2
+- Fix pamtest not being able to run AD auths when using forks
+
 * Wed Aug 24 2022 Antonio Torres <antorres@redhat.com> - 0.4-1
 - Update to 0.4 upstream release
 

--- a/src/pamtest.c
+++ b/src/pamtest.c
@@ -235,6 +235,21 @@ int main(int argc, const char **argv)
                 break;
             }
         }
+        for (i = 0; i < ad_logins; i++) {
+            pid = fork();
+            switch(pid) {
+            case -1:  /* failure */
+                fprintf(stderr, "fork() error: %s\n", strerror(errno));
+                exit(1);
+                break;
+            case 0:  /* child */
+                call_pam(ad_usernames[i]);
+                exit(0);
+                break;
+            default: /* parent */
+                break;
+            }
+        }
         waitpid(-1, &status, 0);
     } else {  // threads
         for (i = 0; i < ipa_logins; i++) {


### PR DESCRIPTION
pamtest was unable to perform AD authentications when using the -f option.

Signed-off-by: Antonio Torres <antorres@redhat.com>