### PR TITLE
Fix counting of available hosts

### DIFF
--- a/src/ipaperftest/providers/idmci.py
+++ b/src/ipaperftest/providers/idmci.py
@@ -104,5 +104,7 @@ class IdMCIProvider(Provider):
         # active fedora-34 41df92f5-5f47-426a-9267-47758d6b9098 fedora34.idmci.test 10.0.199.6 None None  # noqa: E501
         for line in mrack_output.splitlines():
             info = line.split(" ")
+            if info[0] != "active":
+                continue
             name = info[3].split(".")[0]  # don't include full domain
             self.hosts[name] = info[4]


### PR DESCRIPTION
Mrack added a new line listing installed providers to 'mrack list' output, causing our parser to log an additional line as a new host. Filter lines that don't list a host.

Signed-off-by: Antonio Torres <antorres@redhat.com>