### PR TITLE
AuthenticationTest: add option to spread authentications

### DIFF
--- a/src/ipaperftest/core/main.py
+++ b/src/ipaperftest/core/main.py
@@ -161,6 +161,11 @@ class RunTest:
     help="Lifetime in hours of IdM-CI hosts.",
     default=8,
 )
+@click.option(
+    "--auth-spread",
+    help="Time range in seconds to spread auths in AuthenticationTest",
+    default=0,
+)
 @click.pass_context
 def main(
     ctx,
@@ -180,6 +185,7 @@ def main(
     custom_repo_url="",
     provider="idmci",
     idmci_lifetime=8,
+    auth_spread=0,
 ):
 
     tests = RunTest(['ipaperftest.registry'])

--- a/src/ipaperftest/plugins/authenticationtest.py
+++ b/src/ipaperftest/plugins/authenticationtest.py
@@ -200,10 +200,11 @@ class AuthenticationTest(Plugin):
                 continue
             installed += 1
             # spread the pamtest execution
-            if installed % 30 == 0:
-                sleep_time += 20
+            spread = 0
+            if ctx.params["auth_spread"] > 0:
+                spread = random.randrange(0, int(ctx.params['auth_spread']))
             cmds = [
-                "sleep $(( {} - $(date +%s) ))".format(str(client_auth_time)),
+                "sleep $(( {} - $(date +%s) ))".format(str(client_auth_time + spread)),
                 "sudo pamtest {} --threads {} --ad-threads {} -o pamtest.log".format(
                     '-f' if ctx.params["disable_selinux"] else '',
                     str(ctx.params["threads"]),


### PR DESCRIPTION
We want to simulate environments where authentications are spreaded in a time range instead of all being executed simultaneously, so add an option for it.

Signed-off-by: Antonio Torres <antorres@redhat.com>