### PR TITLE
AuthenticationTest: use minutes for spread instead of seconds

### DIFF
--- a/src/ipaperftest/core/main.py
+++ b/src/ipaperftest/core/main.py
@@ -163,7 +163,7 @@ class RunTest:
 )
 @click.option(
     "--auth-spread",
-    help="Time range in seconds to spread auths in AuthenticationTest",
+    help="Time range in minutes to spread auths in AuthenticationTest",
     default=0,
 )
 @click.pass_context

--- a/src/ipaperftest/plugins/authenticationtest.py
+++ b/src/ipaperftest/plugins/authenticationtest.py
@@ -202,7 +202,7 @@ class AuthenticationTest(Plugin):
             # spread the pamtest execution
             spread = 0
             if ctx.params["auth_spread"] > 0:
-                spread = random.randrange(0, int(ctx.params['auth_spread']))
+                spread = random.randrange(0, int(ctx.params['auth_spread'])) * 60
             cmds = [
                 "sleep $(( {} - $(date +%s) ))".format(str(client_auth_time + spread)),
                 "sudo pamtest {} --threads {} --ad-threads {} -o pamtest.log".format(


### PR DESCRIPTION
By using minutes instead of seconds, the authentications are spreaded more evenly, since it guarantees there will be at least 1 minute of difference between authentications that aren't simultaneous.

Signed-off-by: Antonio Torres <antorres@redhat.com>