### PR TITLE
Configure default repos in RHEL systems

### DIFF
--- a/src/ipaperftest/core/constants.py
+++ b/src/ipaperftest/core/constants.py
@@ -60,6 +60,7 @@ phases:
 - name: prep
   steps:
   - playbook: prep/redhat-base.yaml
+  - playbook: prep/repos.yaml
 - name: teardown
   steps:
   - playbook: teardown/mrack-destroy.yaml


### PR DESCRIPTION
We need to enable repositories in RHEL in order to install needed packages such as `sysstat` or `ipa-server`.