### PR TITLE
Return number of successes in test result

### DIFF
--- a/src/ipaperftest/plugins/apitest.py
+++ b/src/ipaperftest/plugins/apitest.py
@@ -170,11 +170,12 @@ class APITest(Plugin):
             f.write(returncodes)
 
         if commands_succeeded == ctx.params['amount']:
-            yield Result(self, SUCCESS, msg="All commands executed successfully.")
+            yield Result(self, SUCCESS, msg="All commands executed successfully.",
+                         successes=commands_succeeded)
         else:
             yield Result(self, ERROR,
-                         error="Not all commands completed succesfully (%s/%s). "
-                         "Check logs." % (commands_succeeded, ctx.params['amount']))
+                         error="Not all commands completed succesfully (%s/%s). Check logs." %
+                         (commands_succeeded, ctx.params['amount']), successes=commands_succeeded)
 
         yield Result(self, SUCCESS, msg="Test executed in {} seconds.".format(self.execution_time))
 

--- a/src/ipaperftest/plugins/authenticationtest.py
+++ b/src/ipaperftest/plugins/authenticationtest.py
@@ -263,9 +263,8 @@ class AuthenticationTest(Plugin):
                          error="None of the threads returned results.")
         total_percentage = round((total_successes / total_threads) * 100)
 
-        print("{} threads out of {} succeeded ({}%)".format(
-            total_successes, total_threads, total_percentage)
-        )
+        yield Result(self, SUCCESS, msg="{} threads out of {} succeeded ({}%)".format(
+            total_successes, total_threads, total_percentage), successes=total_successes)
 
         if total_percentage == 100:
             yield Result(self, SUCCESS, msg="All threads succeded.")

--- a/src/ipaperftest/plugins/enrollmenttest.py
+++ b/src/ipaperftest/plugins/enrollmenttest.py
@@ -92,12 +92,14 @@ class EnrollmentTest(Plugin):
                 int(host_find_output) == self.clients_succeeded + non_client_hosts
                 and len(self.provider.hosts.keys()) == self.clients_succeeded + non_client_hosts
             ):
-                yield Result(self, SUCCESS, msg="All clients enrolled succesfully.")
+                yield Result(self, SUCCESS, msg="All clients enrolled succesfully.",
+                             successes=self.clients_succeeded)
             else:
                 yield Result(self, ERROR,
                              error="Client installs succeeded number (%s) "
                              "does not match host-find output (%s)."
-                             % (self.clients_succeeded, host_find_output))
+                             % (self.clients_succeeded, host_find_output),
+                             successes=self.clients_succeeded)
         except ValueError:
             yield Result(self, ERROR,
                          error="Failed to convert host-find output to int. Value was: %s"


### PR DESCRIPTION
Return the number of successes for each test as part of the result JSON, so it can be easily parsed by a test runner.