### PR TITLE
Update base images to Fedora 38

### DIFF
--- a/src/ipaperftest/providers/idmci.py
+++ b/src/ipaperftest/providers/idmci.py
@@ -61,8 +61,8 @@ class IdMCIProvider(Provider):
 
         server_img = ctx.params["server_image"]
         client_img = ctx.params["client_image"]
-        self.server_image = server_img if server_img else "fedora-34"
-        self.client_image = client_img if client_img else "fedora-34"
+        self.server_image = server_img if server_img else "fedora-38"
+        self.client_image = client_img if client_img else "fedora-38"
 
         images = {
             "server": self.server_image,

--- a/src/ipaperftest/providers/vagrant.py
+++ b/src/ipaperftest/providers/vagrant.py
@@ -67,8 +67,8 @@ class VagrantProvider(Provider):
 
         server_img = ctx.params["server_image"]
         client_img = ctx.params["client_image"]
-        self.server_image = server_img if server_img else "antorres/fedora-34-ipa-client"
-        self.client_image = client_img if client_img else "antorres/fedora-34-ipa-client"
+        self.server_image = server_img if server_img else "fedora/38-cloud-base"
+        self.client_image = client_img if client_img else "fedora/38-cloud-base"
 
         images = {
             "server": self.server_image,


### PR DESCRIPTION
Default base image for IdM-CI and Vagrant providers was set to Fedora 34, which is no longer supported and got its chroots in COPR removed. Update to the latest stable release, Fedora 38.