### PR TITLE
Restart SSSD after disabling the SELinux provider

### DIFF
--- a/src/ipaperftest/core/constants.py
+++ b/src/ipaperftest/core/constants.py
@@ -562,6 +562,10 @@ ANSIBLE_AUTHENTICATIONTEST_NOSELINUX_CONFIG_PLAYBOOK = """
       path: /etc/sssd/sssd.conf
       line: selinux_provider = none
       insertafter: id_provider = ipa
+  - name: "Restart SSSD"
+    service:
+      name: sssd
+      state: restarted
 """
 
 ANSIBLE_GROUPSIZETEST_SERVER_CONFIG_PLAYBOOK = """


### PR DESCRIPTION
This is needed in the AuthenticationTest. With SELinux enabled there is a lock in SSSD that prevents simultaneous logins.