### PR TITLE
Add run arguments to results output

### DIFF
--- a/src/ipaperftest/core/main.py
+++ b/src/ipaperftest/core/main.py
@@ -75,6 +75,7 @@ class RunTest:
                     continue
                 selected_plugin = plugin
                 try:
+                    self.results.add(Result(plugin, SUCCESS, args=sys.argv))
                     for result in plugin.execute(ctx):
                         self.results.add(result)
                 except Exception:


### PR DESCRIPTION
Include the list of arguments for the run to the list of results.