### PR TITLE
ansible config: set private key explicitly

### DIFF
--- a/src/ipaperftest/core/constants.py
+++ b/src/ipaperftest/core/constants.py
@@ -156,6 +156,7 @@ ANSIBLE_CFG_TEMPLATE = """
 remote_user = root
 host_key_checking = False
 deprecation_warnings = False
+private_key_file = {private_key_path}
 roles_path   = {cwd}/ansible-freeipa/roles
 library      = {cwd}/ansible-freeipa/plugins/modules
 module_utils = {cwd}/ansible-freeipa/plugins/module_utils

--- a/src/ipaperftest/core/plugin.py
+++ b/src/ipaperftest/core/plugin.py
@@ -153,7 +153,7 @@ class Plugin:
         with open("runner_metadata/ansible.cfg", "w") as f:
             f.write(ANSIBLE_CFG_TEMPLATE.format(
                 cwd=os.path.join(os.getcwd(), "runner_metadata"),
-                private_key_path=ctx.params["private_key"],
+                private_key_path=ctx.params["private_key"] or self.provider.default_private_key,
                 default_private_key_path=self.provider.default_private_key
                 )
             )


### PR DESCRIPTION
Apart from adding the SSH private key to the SSH arguments, we need to set the `private_key_file` option in ansible.cfg.